### PR TITLE
MBS-8480: Add setting in config.php to disable plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ After that you have to go to http://your-moodle/admin (Site administration -> No
 
 ### Using:
 To use Moodle Adminer go to "Site administration" -> "Server" -> "Moodle Adminer".
+
+### Config-Setting
+While the administrator is desired on development and test instances, it can sometimes be undesirable for the site admin to have direct DB access on production environments. For this use case, the following setting can be made in config.php to prevent access.
+
+```
+$CFG->local_adminer_disabled = true;
+```

--- a/index.php
+++ b/index.php
@@ -98,6 +98,9 @@ $content->adminerurl         = $adminerurl->out(false);
 $content->adminerlaunchtitle = get_string('launchadminer', 'local_adminer');
 $content->title              = get_string('pluginname', 'local_adminer');
 $content->modalcss           = $modalcss;
+if (!empty($CFG->local_adminer_disabled)) {
+    $content->disabled = $CFG->local_adminer_disabled;
+}
 if ($legacycss) {
     $content->legacycss = new \moodle_url('/local/adminer/legacy/legacy.css');
 }

--- a/lang/en/local_adminer.php
+++ b/lang/en/local_adminer.php
@@ -26,6 +26,7 @@
 
 $string['adminer:useadminer'] = 'Use Adminer';
 $string['config_startwithdb'] = 'Start adminer with current database';
+$string['disabled'] = 'Adminer is disabled in config.php, because `$CFG->local_adminer_disabled = true;` is set.';
 $string['launchadminer'] = 'Launch Adminer';
 $string['pagenotusedinmoodle'] = 'This page can not be used in Moodle';
 $string['pluginname'] = 'Moodle Adminer';

--- a/templates/adminer.mustache
+++ b/templates/adminer.mustache
@@ -34,6 +34,9 @@
     }
 }}
 
+
+{{^disabled}}
+
 {{#legacycss}}
     <link rel="stylesheet" href="{{{legacycss}}}">
 {{/legacycss}}
@@ -77,3 +80,9 @@
         addcss.init(`{{{modalcss}}}`);
     });
 {{/js}}
+
+{{/disabled}}
+
+{{#disabled}}
+<div class="alert alert-info" role="alert">{{#str}} disabled, local_adminer {{/str}}</div>
+{{/disabled}}


### PR DESCRIPTION
While the administrator is desired on development and test instances, it can sometimes be undesirable for the site admin to have direct DB access on production environments. For this use case, a setting can be made in config.php to prevent access.