### PR TITLE
add adminer user option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,9 @@ Due to the high security risk of using Adminer, an additional key can be defined
 `$CFG->local_adminer_secret = 'your-secret-key';`<br>
 If you want to fully disable Adminer you can define "!!!" as Adminer secret.<br>
 **Example:**<br>
-`$CFG->local_adminer_secret = '!!!';`
+`$CFG->local_adminer_secret = '!!!';`  
+
+You can also (cumulative) set a specific adminer user and password in **config.php**.<br>
+**Example:**<br>
+`$CFG->local_adminer_user = 'adminer';`<br>
+`$CFG->local_adminer_password = 'adminerpwd';`<br>

--- a/lib/plugins/mdllogin.php
+++ b/lib/plugins/mdllogin.php
@@ -23,6 +23,7 @@ class AdminerMdlLogin {
      * Returns the database credentials for Adminer login.
      *
      * If the database port is set in the Moodle configuration, it is appended the to the host.
+     * If the specific Adminer database user and password are set in the Moodle configuration, they are used.
      *
      * @return array an array containing the database host, user, and password
      */
@@ -33,10 +34,18 @@ class AdminerMdlLogin {
             $portstring = '';
         }
 
+        if (!empty($this->mdlcfg->local_adminer_user) && !empty($this->mdlcfg->local_adminer_password)) {
+            $dbuser = $this->mdlcfg->local_adminer_user;
+            $dbpass = $this->mdlcfg->local_adminer_password;
+        } else {
+            $dbuser = $this->mdlcfg->dbuser;
+            $dbpass = $this->mdlcfg->dbpass;
+        }
+    
         return [
             $this->mdlcfg->dbhost . $portstring,
-            $this->mdlcfg->dbuser,
-            $this->mdlcfg->dbpass,
+            $dbuser,
+            $dbpass,
         ];
     }
 


### PR DESCRIPTION
Hello,
It could be great to add a specific user for adminer in the config.php to improve security. For exemple, to have a read only user.
I did a (bad) issue here : https://tracker.moodle.org/browse/MDL-85215

I think, my PR need the documentation for the front in the admin panel, but i didn't know how it works.